### PR TITLE
Fixed the animation-breaking bug

### DIFF
--- a/CustomPlayerModels-1.12/src/main/java/com/tom/cpm/client/PlayerProfile.java
+++ b/CustomPlayerModels-1.12/src/main/java/com/tom/cpm/client/PlayerProfile.java
@@ -84,6 +84,7 @@ public class PlayerProfile extends Player<EntityPlayer, ModelPlayer> {
 		else if(player.isElytraFlying())pose = VanillaPose.FLYING;
 		else if(player.fallDistance > 4)pose = VanillaPose.FALLING;
 		else if(player.isRiding() && (player.getRidingEntity() != null && player.getRidingEntity().shouldRiderSit()))pose = VanillaPose.RIDING;
+		else if(player.isSprinting() && player.isSneaking())pose = VanillaPose.SNEAKING;
 		else if(player.isSprinting())pose = VanillaPose.RUNNING;
 		else if(player.isSneaking())pose = VanillaPose.SNEAKING;
 		else if(Math.abs(player.posX - player.prevPosX) > 0 || Math.abs(player.posZ - player.prevPosZ) > 0)pose = VanillaPose.WALKING;

--- a/CustomPlayerModels-1.16/src/main/java/com/tom/cpm/client/PlayerProfile.java
+++ b/CustomPlayerModels-1.16/src/main/java/com/tom/cpm/client/PlayerProfile.java
@@ -91,6 +91,7 @@ public class PlayerProfile extends Player<PlayerEntity, Model> {
 		else if(player.fallDistance > 4)pose = VanillaPose.FALLING;
 		else if(player.isPassenger() && (player.getVehicle() != null && player.getVehicle().shouldRiderSit()))pose = VanillaPose.RIDING;
 		else if(p == Pose.SWIMMING)pose = VanillaPose.SWIMMING;
+		else if(player.isSprinting() && p == Pose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(player.isSprinting())pose = VanillaPose.RUNNING;
 		else if(p == Pose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(Math.abs(player.getX() - player.xo) > 0 || Math.abs(player.getZ() - player.zo) > 0)pose = VanillaPose.WALKING;

--- a/CustomPlayerModels-1.17/src/main/java/com/tom/cpm/client/PlayerProfile.java
+++ b/CustomPlayerModels-1.17/src/main/java/com/tom/cpm/client/PlayerProfile.java
@@ -91,6 +91,7 @@ public class PlayerProfile extends Player<net.minecraft.world.entity.player.Play
 		else if(player.fallDistance > 4)pose = VanillaPose.FALLING;
 		else if(player.isPassenger() && (player.getVehicle() != null && player.getVehicle().shouldRiderSit()))pose = VanillaPose.RIDING;
 		else if(p == Pose.SWIMMING)pose = VanillaPose.SWIMMING;
+		else if(player.isSprinting() && p == Pose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(player.isSprinting())pose = VanillaPose.RUNNING;
 		else if(p == Pose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(Math.abs(player.getX() - player.xo) > 0 || Math.abs(player.getZ() - player.zo) > 0)pose = VanillaPose.WALKING;

--- a/CustomPlayerModels-1.18/src/main/java/com/tom/cpm/client/PlayerProfile.java
+++ b/CustomPlayerModels-1.18/src/main/java/com/tom/cpm/client/PlayerProfile.java
@@ -91,6 +91,7 @@ public class PlayerProfile extends Player<net.minecraft.world.entity.player.Play
 		else if(player.fallDistance > 4)pose = VanillaPose.FALLING;
 		else if(player.isPassenger() && (player.getVehicle() != null && player.getVehicle().shouldRiderSit()))pose = VanillaPose.RIDING;
 		else if(p == Pose.SWIMMING)pose = VanillaPose.SWIMMING;
+		else if(player.isSprinting() && p == Pose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(player.isSprinting())pose = VanillaPose.RUNNING;
 		else if(p == Pose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(Math.abs(player.getX() - player.xo) > 0 || Math.abs(player.getZ() - player.zo) > 0)pose = VanillaPose.WALKING;

--- a/CustomPlayerModels-1.7/src/main/java/com/tom/cpm/client/PlayerProfile.java
+++ b/CustomPlayerModels-1.7/src/main/java/com/tom/cpm/client/PlayerProfile.java
@@ -125,6 +125,7 @@ public class PlayerProfile extends Player<EntityPlayer, ModelBase> {
 		else if(player.isDead)pose = VanillaPose.DYING;
 		else if(player.fallDistance > 4 && !player.capabilities.isFlying)pose = VanillaPose.FALLING;
 		else if(player.isRiding())pose = VanillaPose.RIDING;
+		else if(player.isSprinting() && player.isSneaking())pose = VanillaPose.SNEAKING;
 		else if(player.isSprinting())pose = VanillaPose.RUNNING;
 		else if(player.isSneaking())pose = VanillaPose.SNEAKING;
 		else if(Math.abs(player.posX - player.prevPosX) > 0 || Math.abs(player.posZ - player.prevPosZ) > 0)pose = VanillaPose.WALKING;

--- a/CustomPlayerModels-1.8/src/main/java/com/tom/cpm/client/PlayerProfile.java
+++ b/CustomPlayerModels-1.8/src/main/java/com/tom/cpm/client/PlayerProfile.java
@@ -130,6 +130,7 @@ public class PlayerProfile extends Player<EntityPlayer, ModelBase> {
 		else if(player.isDead)pose = VanillaPose.DYING;
 		else if(player.fallDistance > 4 && !player.capabilities.isFlying)pose = VanillaPose.FALLING;
 		else if(player.isRiding() && (player.ridingEntity != null && player.ridingEntity.shouldRiderSit()))pose = VanillaPose.RIDING;
+		else if(player.isSprinting() && player.isSneaking())pose = VanillaPose.SNEAKING;
 		else if(player.isSprinting())pose = VanillaPose.RUNNING;
 		else if(player.isSneaking())pose = VanillaPose.SNEAKING;
 		else if(Math.abs(player.posX - player.prevPosX) > 0 || Math.abs(player.posZ - player.prevPosZ) > 0)pose = VanillaPose.WALKING;

--- a/CustomPlayerModelsFabric-1.16/src/main/java/com/tom/cpm/client/PlayerProfile.java
+++ b/CustomPlayerModelsFabric-1.16/src/main/java/com/tom/cpm/client/PlayerProfile.java
@@ -134,6 +134,7 @@ public class PlayerProfile extends Player<PlayerEntity, Model> {
 		else if(player.fallDistance > 4)pose = VanillaPose.FALLING;
 		else if(player.hasVehicle())pose = VanillaPose.RIDING;
 		else if(p == EntityPose.SWIMMING)pose = VanillaPose.SWIMMING;
+		else if(player.isSprinting() && p == EntityPose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(player.isSprinting())pose = VanillaPose.RUNNING;
 		else if(p == EntityPose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(Math.abs(player.getX() - player.prevX) > 0 || Math.abs(player.getZ() - player.prevZ) > 0)pose = VanillaPose.WALKING;

--- a/CustomPlayerModelsFabric-1.17/src/main/java/com/tom/cpm/client/PlayerProfile.java
+++ b/CustomPlayerModelsFabric-1.17/src/main/java/com/tom/cpm/client/PlayerProfile.java
@@ -135,6 +135,7 @@ public class PlayerProfile extends Player<PlayerEntity, Model> {
 		else if(player.fallDistance > 4)pose = VanillaPose.FALLING;
 		else if(player.hasVehicle())pose = VanillaPose.RIDING;
 		else if(p == EntityPose.SWIMMING)pose = VanillaPose.SWIMMING;
+		else if(player.isSprinting() && p == EntityPose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(player.isSprinting())pose = VanillaPose.RUNNING;
 		else if(p == EntityPose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(Math.abs(player.getX() - player.prevX) > 0 || Math.abs(player.getZ() - player.prevZ) > 0)pose = VanillaPose.WALKING;

--- a/CustomPlayerModelsFabric-1.18/src/main/java/com/tom/cpm/client/PlayerProfile.java
+++ b/CustomPlayerModelsFabric-1.18/src/main/java/com/tom/cpm/client/PlayerProfile.java
@@ -135,6 +135,7 @@ public class PlayerProfile extends Player<PlayerEntity, Model> {
 		else if(player.fallDistance > 4)pose = VanillaPose.FALLING;
 		else if(player.hasVehicle())pose = VanillaPose.RIDING;
 		else if(p == EntityPose.SWIMMING)pose = VanillaPose.SWIMMING;
+		else if(player.isSprinting() && p == EntityPose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(player.isSprinting())pose = VanillaPose.RUNNING;
 		else if(p == EntityPose.CROUCHING)pose = VanillaPose.SNEAKING;
 		else if(Math.abs(player.getX() - player.prevX) > 0 || Math.abs(player.getZ() - player.prevZ) > 0)pose = VanillaPose.WALKING;


### PR DESCRIPTION
There was a bug that broke model's animation. If you run, press shift (sneak) without stopping movement, the mod will continue using running animation for model, even though the player is sneaking.

Steps to reproduce the bug:
1. Load custom model.
2. Start sprinting.
3. Without stopping moving, press shift (sneak).

Expected behaviour: the model's animation switches to "sneaking"
Actual result: the model keeps using "running" animation while sneaking

https://user-images.githubusercontent.com/63594377/148662849-10fe76f6-79a1-44f7-ad37-0f4f848670d0.mp4


