### PR TITLE
Skip reading of ModelFile icon on server side

### DIFF
--- a/CustomPlayerModels/src/shared/java/com/tom/cpm/shared/io/ModelFile.java
+++ b/CustomPlayerModels/src/shared/java/com/tom/cpm/shared/io/ModelFile.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.tom.cpm.shared.MinecraftClientAccess;
 import com.tom.cpm.shared.definition.Link;
 import com.tom.cpm.shared.definition.ModelDefinitionLoader;
 import com.tom.cpm.shared.io.IOHelper.ImageBlock;
@@ -42,10 +43,14 @@ public class ModelFile {
 			mf.overflowLocal = ovf;
 			mf.link = new Link(h);
 		}
-		ImageBlock block = h.readImage();
-		if(block.getWidth() > 256 || block.getHeight() > 256)
-			throw new IOException("Texture size too large");
-		mf.icon = block;
+		if (MinecraftClientAccess.get() != null) {
+			ImageBlock block = h.readImage();
+			if (block.getWidth() > 256 || block.getHeight() > 256)
+				throw new IOException("Texture size too large");
+			mf.icon = block;
+		} else {
+			h.readNextBlock();
+		}
 		cis.checkSum();
 		return mf;
 	}


### PR DESCRIPTION
**Type:** Bugfix

## Summary

This change allows to read `ModelFile`s even on the server side.

## What does this fix?

Currently, only the client side can read `ModelFile`s, because `ModelFile.load` requires an instance of `MinecraftClientAccess`.

This, however, is only needed to read the `ModelFile`'s `icon` property, which is neither necessary for the models to properly work in-game, nor is it used on servers themselves.
Therefore, it can safely be skipped, allowing the server side to load `ModelFile`s.

## Why is this useful?

With this fix, CPM plugins utilizing the `CommonAPI` can now read `ModelFile`s on the server side.
This allows the creation of mods that enforce custom `ModelFile`s as player skins using `ICommonAPI#setPlayerModel(Class<P>, P, ModelFile, boolean)`, operating purely server-side as CPM plugins. 

## Notes

There are probably better ways of achieving the same result
(for example, properly decoupling the loading of the `icon` property from `MinecraftClientAccess`).
This is merely what I did "quick & dirty" to make it work.

If you have further suggestions to improve this change, feel free to add them or tell me what you'd recommend.