### PR TITLE
Add repeat to spinners when holding down mouse

### DIFF
--- a/CustomPlayerModels/src/shared/java/com/tom/cpl/gui/elements/Spinner.java
+++ b/CustomPlayerModels/src/shared/java/com/tom/cpl/gui/elements/Spinner.java
@@ -11,6 +11,7 @@ import com.tom.cpl.gui.MouseEvent;
 import com.tom.cpl.gui.util.TabFocusHandler.Focusable;
 import com.tom.cpl.math.Box;
 import com.tom.cpm.externals.com.udojava.evalex.Expression.ExpressionException;
+import com.tom.cpm.shared.MinecraftClientAccess;
 import com.tom.cpm.shared.util.ExpressionExt;
 
 public class Spinner extends GuiElement implements Focusable {
@@ -21,7 +22,7 @@ public class Spinner extends GuiElement implements Focusable {
 	private boolean txtfNeedsUpdate;
 	private String error, lastValue;
 	private MouseEvent currentClick;
-	private float mouseRepeatTimer;
+	private int currentClickStartTime;
 
 	public Spinner(IGui gui) {
 		super(gui);
@@ -55,12 +56,8 @@ public class Spinner extends GuiElement implements Focusable {
 			gui.drawRectangle(bounds.x, bounds.y, bounds.w, bounds.h, 0xffff0000);
 		}
 		// mouse click repeat
-		if (currentClick != null) {
-			mouseRepeatTimer -= partialTicks;
-			if (mouseRepeatTimer <= 0) {
+		if (currentClick != null && MinecraftClientAccess.get().getPlayerRenderManager().getAnimationEngine().getTicks() - currentClickStartTime > 10) {
 				arrowClicked(currentClick);
-				mouseRepeatTimer = 1;
-			}
 		}
 	}
 
@@ -71,7 +68,7 @@ public class Spinner extends GuiElement implements Focusable {
 			arrowClicked(e);
 			// new mouse event since mouseDrag modifies its position
 			currentClick = new MouseEvent(e.x, e.y, e.btn);
-			mouseRepeatTimer = 10;
+			currentClickStartTime = MinecraftClientAccess.get().getPlayerRenderManager().getAnimationEngine().getTicks();
 		}
 		txtf.mouseClick(e);
 	}

--- a/CustomPlayerModels/src/shared/java/com/tom/cpl/gui/elements/Spinner.java
+++ b/CustomPlayerModels/src/shared/java/com/tom/cpl/gui/elements/Spinner.java
@@ -57,6 +57,7 @@ public class Spinner extends GuiElement implements Focusable {
 		}
 		// mouse click repeat
 		if (currentClick != null && MinecraftClientAccess.get().getPlayerRenderManager().getAnimationEngine().getTicks() - currentClickStartTime > 10) {
+				currentClickStartTime++;
 				arrowClicked(currentClick);
 		}
 	}


### PR DESCRIPTION
This implements this suggestion from the discord:
![image](https://github.com/user-attachments/assets/0ebcbc97-c933-4626-89ca-e872f6722052)
https://discord.com/channels/811508670205788211/829768829542334544/1269740342517698690

I've implemented it in a way where the longer you hold down the mouse button, the faster it goes so that it gives fine-ish control over small adjustments while still allowing you to quickly go larger distances.

I hope just opening PRs like this is fine. (and if it is, I might do more in the future)
If not, I'm sorry.