### PR TITLE
Switch to getMethod for addChannel invocation

### DIFF
--- a/CustomPlayerModels-Bukkit/src/main/java/com/tom/cpm/bukkit/Network.java
+++ b/CustomPlayerModels-Bukkit/src/main/java/com/tom/cpm/bukkit/Network.java
@@ -111,7 +111,7 @@ public class Network implements PluginMessageListener, Listener {
 	@EventHandler
 	public void onPlayerJoin(PlayerJoinEvent evt) {
 		try {
-			Method addChn = evt.getPlayer().getClass().getDeclaredMethod("addChannel", String.class);
+			Method addChn = evt.getPlayer().getClass().getMethod("addChannel", String.class);
 			netHandler.registerOut(c -> addChn.invoke(evt.getPlayer(), c));
 		} catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
On Paper 1.21.7+, `CraftPlayer#addChannel` was moved up into an [implementation](https://github.com/PaperMC/Paper/blob/main/paper-server/src/main/java/io/papermc/paper/connection/PluginMessageBridgeImpl.java). As a result of this, invoking `Class#getDeclaredMethod` produces an exception on every player join.

Switched to `Class#getMethod` to account for this and restore the functionality for clients.