### PR TITLE
[b1.7.3 babric] fix duplicating chat message on server

### DIFF
--- a/CustomPlayerModels-b1.7.3/src/main/java/com/tom/cpm/mixin/client/MinecraftMixin.java
+++ b/CustomPlayerModels-b1.7.3/src/main/java/com/tom/cpm/mixin/client/MinecraftMixin.java
@@ -112,7 +112,7 @@ public abstract class MinecraftMixin {
 		if (!isWorldRemote())cbi.setReturnValue(true);
 		if (command.startsWith("/")) {
 			SinglePlayerCommands.executeCommand((Minecraft) (Object) this, command);
-		} else {
+		} else if (!isWorldRemote()) {
 			inGameHud.addChatMessage("<" + player.name + "> " + command);
 		}
 	}


### PR DESCRIPTION
### Changes:

- Fixes an issue where chat messages are duplicated for the client when sending any message on multiplayer (b1.7.3, babric)

### Before:
<img width="1072" height="109" alt="OGGWy68QPP" src="https://github.com/user-attachments/assets/836360d7-ef6d-447f-89c9-3e79deff241f" />
<img width="1466" height="79" alt="ffiSxjbMNG" src="https://github.com/user-attachments/assets/763ecdb1-e057-4dc6-ba59-224124061527" />

### After:
<img width="2560" height="1351" alt="vXBzHfTRbQ" src="https://github.com/user-attachments/assets/7d0590d4-25eb-4334-9eb3-abe6b606ae45" />

