### PR TITLE
Fix PV compat crash with other improvements

### DIFF
--- a/CPM-PV-Compat/gradle.properties
+++ b/CPM-PV-Compat/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx4G
 org.gradle.daemon=false
 
-mod_version=1.1.1
+mod_version=1.1.2
 
 # CPM versions
 cpm_api_version=0.6.26

--- a/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMAddon.java
+++ b/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMAddon.java
@@ -62,11 +62,21 @@ public class CPMAddon implements AddonInitializer {
 		if (!connection.isPresent()) return false;
 
 		Optional<VoicePlayerInfo> playerInfo = connection.get().getPlayerById(player);
-		if (!playerInfo.isPresent())return false;
-		if (playerInfo.get().isMuted() || playerInfo.get().isMicrophoneMuted())return true;
+		if (!playerInfo.isPresent()) return false;
+
+		boolean isMutedOnServer = playerInfo.get().isMuted();
+		boolean inMutedOnClient = voiceClient.getConfig()
+				.getVoice()
+				.getVolumes()
+				.getMute("source_" + player)
+				.value();
+
+		if (isMutedOnServer || inMutedOnClient) return true;
+
 		if (MinecraftClientAccess.get().getCurrentClientPlayer().getUUID().equals(player)) {
 			return voiceClient.getConfig().getVoice().getMicrophoneDisabled().value();
 		}
+
 		return false;
 	}
 }

--- a/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMAddon.java
+++ b/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMAddon.java
@@ -3,13 +3,12 @@ package com.tom.cpmpvc;
 import java.util.Optional;
 import java.util.UUID;
 
-import com.google.inject.Inject;
-
 import com.tom.cpm.shared.MinecraftClientAccess;
 
 import su.plo.voice.api.addon.AddonInitializer;
 import su.plo.voice.api.addon.AddonLoaderScope;
 import su.plo.voice.api.addon.ClientAddonsLoader;
+import su.plo.voice.api.addon.InjectPlasmoVoice;
 import su.plo.voice.api.addon.annotation.Addon;
 import su.plo.voice.api.client.PlasmoVoiceClient;
 import su.plo.voice.api.client.connection.ServerConnection;
@@ -19,14 +18,14 @@ import su.plo.voice.api.event.EventSubscribe;
 import su.plo.voice.client.audio.source.ClientPlayerSource;
 import su.plo.voice.proto.data.player.VoicePlayerInfo;
 
-@Addon(id = CPMPVC.MOD_ID, scope = AddonLoaderScope.CLIENT, version = "2.1.1", authors = "tom5454")
+@Addon(id = CPMPVC.MOD_ID, scope = AddonLoaderScope.CLIENT, version = "2.1.2", authors = "tom5454")
 public class CPMAddon implements AddonInitializer {
 	public static final CPMAddon INSTANCE = new CPMAddon();
 
 	private CPMAddon() {
 	}
 
-	@Inject
+	@InjectPlasmoVoice
 	private PlasmoVoiceClient voiceClient;
 
 	@Override

--- a/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMAddon.java
+++ b/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMAddon.java
@@ -11,6 +11,7 @@ import su.plo.voice.api.addon.ClientAddonsLoader;
 import su.plo.voice.api.addon.InjectPlasmoVoice;
 import su.plo.voice.api.addon.annotation.Addon;
 import su.plo.voice.api.client.PlasmoVoiceClient;
+import su.plo.voice.api.client.audio.capture.ClientActivation;
 import su.plo.voice.api.client.connection.ServerConnection;
 import su.plo.voice.api.client.event.audio.capture.AudioCaptureProcessedEvent;
 import su.plo.voice.api.client.event.audio.source.AudioSourceWriteEvent;
@@ -39,7 +40,13 @@ public class CPMAddon implements AddonInitializer {
 
 	@EventSubscribe
 	public void onCaptureProcessed(AudioCaptureProcessedEvent event) {
-		CPMPVC.handle(event.getProcessed().getMono());
+		// AudioCaptureProcessedEvent triggers even when audio is not actually sent to the server
+		// so we have to check if any activation is active right now to see if player is speaking
+		boolean isSpeaking = voiceClient.getActivationManager()
+				.getActivations()
+				.stream().anyMatch(ClientActivation::isActive);
+
+		CPMPVC.handle(isSpeaking ? event.getProcessed().getMono() : null);
 	}
 
 	@EventSubscribe

--- a/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMPVC.java
+++ b/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMPVC.java
@@ -10,7 +10,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
-import com.tom.cpm.api.IClientAPI.MessageSender;
 import com.tom.cpm.shared.MinecraftClientAccess;
 import su.plo.voice.api.util.AudioUtil;
 
@@ -18,7 +17,6 @@ public class CPMPVC {
 	public static final String MOD_ID = "cpmpvc";
 	public static final Logger LOGGER = LogManager.getLogger("CPM-PV Compat");
 	private static final LoadingCache<UUID, Float> voiceLevelsCache = CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.SECONDS).build(CacheLoader.from(() -> 0f));
-	public static MessageSender mutedSender;
 
 	public static float get(UUID uuid) {
 		try {

--- a/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMPVC.java
+++ b/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMPVC.java
@@ -11,7 +11,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
 import com.tom.cpm.shared.MinecraftClientAccess;
-import su.plo.voice.api.util.AudioUtil;
 
 public class CPMPVC {
 	public static final String MOD_ID = "cpmpvc";
@@ -35,10 +34,62 @@ public class CPMPVC {
 	}
 
 	private static float calcVoiceLevel(short[] data) {
-		return (float) AudioUtil.audioLevelToDoubleRange(AudioUtil.calculateHighestAudioLevel(data));
+		return (float) dbToPerc(getHighestAudioLevel(data));
 	}
 
 	public static boolean isMuted(UUID uuid) {
 		return CPMAddon.INSTANCE.isMuted(uuid);
+	}
+
+	/**
+	 * Calculates the audio level of a signal with specific samples.
+	 *
+	 * @param samples the samples of the signal to calculate the audio level of
+	 * @param offset  the offset in samples in which the samples start
+	 * @param length  the length in bytes of the signal in samples starting at offset
+	 * @return the audio level of the specified signal in db
+	 */
+	private static double calculateAudioLevel(short[] samples, int offset, int length) {
+		double rms = 0D; // root mean square (RMS) amplitude
+
+		for (int i = offset; i < length; i++) {
+			double sample = (double) samples[i] / (double) Short.MAX_VALUE;
+			rms += sample * sample;
+		}
+
+		int sampleCount = length / 2;
+
+		rms = (sampleCount == 0) ? 0 : Math.sqrt(rms / sampleCount);
+
+		double db;
+
+		if (rms > 0D) {
+			db = Math.min(Math.max(20D * Math.log10(rms), -127D), 0D);
+		} else {
+			db = -127D;
+		}
+
+		return db;
+	}
+
+	/**
+	 * Calculates the highest audio level in packs of 100
+	 *
+	 * @param samples the audio samples
+	 * @return the audio level in db
+	 */
+	private static double getHighestAudioLevel(short[] samples) {
+		double highest = -127D;
+		for (int i = 0; i < samples.length; i += 100) {
+			double level = calculateAudioLevel(samples, i, Math.min(i + 100, samples.length));
+			if (level > highest) {
+				highest = level;
+			}
+		}
+		return highest;
+	}
+
+	private static double dbToPerc(double db) {
+		return (db + 127D) / 127D;
 	}
 }

--- a/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMPVC.java
+++ b/CPM-PV-Compat/src/shared/java/com/tom/cpmpvc/CPMPVC.java
@@ -12,6 +12,7 @@ import com.google.common.cache.LoadingCache;
 
 import com.tom.cpm.api.IClientAPI.MessageSender;
 import com.tom.cpm.shared.MinecraftClientAccess;
+import su.plo.voice.api.util.AudioUtil;
 
 public class CPMPVC {
 	public static final String MOD_ID = "cpmpvc";
@@ -36,62 +37,10 @@ public class CPMPVC {
 	}
 
 	private static float calcVoiceLevel(short[] data) {
-		return (float) dbToPerc(getHighestAudioLevel(data));
+		return (float) AudioUtil.audioLevelToDoubleRange(AudioUtil.calculateHighestAudioLevel(data));
 	}
 
 	public static boolean isMuted(UUID uuid) {
 		return CPMAddon.INSTANCE.isMuted(uuid);
-	}
-
-	/**
-	 * Calculates the audio level of a signal with specific samples.
-	 *
-	 * @param samples the samples of the signal to calculate the audio level of
-	 * @param offset  the offset in samples in which the samples start
-	 * @param length  the length in bytes of the signal in samples starting at offset
-	 * @return the audio level of the specified signal in db
-	 */
-	private static double calculateAudioLevel(short[] samples, int offset, int length) {
-		double rms = 0D; // root mean square (RMS) amplitude
-
-		for (int i = offset; i < length; i++) {
-			double sample = (double) samples[i] / (double) Short.MAX_VALUE;
-			rms += sample * sample;
-		}
-
-		int sampleCount = length / 2;
-
-		rms = (sampleCount == 0) ? 0 : Math.sqrt(rms / sampleCount);
-
-		double db;
-
-		if (rms > 0D) {
-			db = Math.min(Math.max(20D * Math.log10(rms), -127D), 0D);
-		} else {
-			db = -127D;
-		}
-
-		return db;
-	}
-
-	/**
-	 * Calculates the highest audio level in packs of 100
-	 *
-	 * @param samples the audio samples
-	 * @return the audio level in db
-	 */
-	private static double getHighestAudioLevel(short[] samples) {
-		double highest = -127D;
-		for (int i = 0; i < samples.length; i += 100) {
-			double level = calculateAudioLevel(samples, i, Math.min(i + 100, samples.length));
-			if (level > highest) {
-				highest = level;
-			}
-		}
-		return highest;
-	}
-
-	private static double dbToPerc(double db) {
-		return (db + 127D) / 127D;
 	}
 }


### PR DESCRIPTION
Fixes crash by swapping `@Inject` with `@InjectPlasmoVoice`:
```log
[16:07:48] [Render thread/ERROR]: Unreported exception thrown!
java.lang.NullPointerException: Cannot invoke "su.plo.voice.api.client.PlasmoVoiceClient.getServerConnection()" because "this.voiceClient" is null
	at knot//com.tom.cpmpvc.CPMAddon.isMuted(CPMAddon.java:55)
	at knot//com.tom.cpmpvc.CPMPVC.isMuted(CPMPVC.java:43)
	...
```

### Other changes not related to crash:
- `AudioCaptureProcessedEvent` now passes audio only when actually speaking (aka using activations).
- `isMuted` now respects client-side mutes.
~~- `AudioUtil` (available in public API) is now used to calculate audio level and convert dB value to `[0, 1]` float range. Although `audioLevelToDoubleRange` actually maps from `[-60, 0]` -> `[0, 1]`, so logic is not the same. But I found it more "accurate", because original `[-127, 0]` -> `[0, 1]` range means that `-60` is `0.5`, which is effectively silence.~~