### PR TITLE
Fix model load breaking when using unofficial authentication servers on Retro versions of Minecraft

### DIFF
--- a/CustomPlayerModels-1.6/src/retro/java/com/tom/cpm/retro/GameProfile.java
+++ b/CustomPlayerModels-1.6/src/retro/java/com/tom/cpm/retro/GameProfile.java
@@ -52,9 +52,7 @@ public class GameProfile {
 					if (skinType == null) {
 						skinType = "default";
 					}
-					if (url.startsWith("http://textures.minecraft.net/texture/")) {
-						textureURLMap.put(tt, url);
-					}
+					textureURLMap.put(tt, url);
 				}
 			}
 		}


### PR DESCRIPTION
When using a custom API server for authentication, versions of the mod that use the retro GameProfile implementation break because it is hard-coded to check what the domain name is

Remove the if statement and it works well!
<img width="2560" height="1389" alt="2026-07-19_14 47 22" src="https://github.com/user-attachments/assets/e86d648a-1653-48de-9d37-d8fb4e0f6394" />
