### PR TITLE
replace btoa with UTF-8 Base64 to resolve i18n error dialog crashes

### DIFF
--- a/Web/src/blockbench/java/com/tom/cpm/blockbench/util/PopupDialogs.java
+++ b/Web/src/blockbench/java/com/tom/cpm/blockbench/util/PopupDialogs.java
@@ -1,5 +1,6 @@
 package com.tom.cpm.blockbench.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Function;
 
@@ -7,6 +8,7 @@ import com.tom.cpm.blockbench.PluginStart;
 import com.tom.cpm.blockbench.convert.WarnEntry;
 import com.tom.cpm.blockbench.proxy.Dialog;
 import com.tom.cpm.web.client.WebMC;
+import com.tom.cpm.web.client.java.Base64;
 import com.tom.cpm.web.client.util.Clipboard;
 import com.tom.cpm.web.client.util.I18n;
 import com.tom.ugwt.client.ExceptionUtil;
@@ -70,7 +72,8 @@ public class PopupDialogs {
 			errorMsg = msg + "\n" + err;
 		}
 		errorMsg += "\nPlatform: " + WebMC.platform;
-		errorDialog.setLines("<p>" + msg + "<br>" + err.toString() + "<br>" + I18n.get("bb-label.pleaseReport") + "<br>" + "Platform: " + WebMC.platform + "<br>" + "<button onclick='" + copyErrorFunc + "(\"" + DomGlobal.btoa(errorMsg) + "\")'>" + I18n.get("bb-button.copyErrorMsg") + "</button></p>");
+
+		errorDialog.setLines("<p>" + msg + "<br>" + err.toString() + "<br>" + I18n.get("bb-label.pleaseReport") + "<br>" + "Platform: " + WebMC.platform + "<br>" + "<button onclick='" + copyErrorFunc + "(\"" + Base64.getEncoder().encodeToString(errorMsg.getBytes(StandardCharsets.UTF_8)) + "\")'>" + I18n.get("bb-button.copyErrorMsg") + "</button></p>");
 		errorDialog.show();
 	}
 


### PR DESCRIPTION
fix:

``` text
Uncaught (in promise) InvalidCharacterError: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.
    at Fac ((Plugin):cpm_plugin.js:2260:536)
    at d.Y3b ((Plugin):cpm_plugin.js:2015:60)
    at d ((Plugin):cpm_plugin.js:18:47)
Fac	@	(Plugin):cpm_plugin.js:2260
Y3b	@	(Plugin):cpm_plugin.js:2015
d	@	(Plugin):cpm_plugin.js:18
Promise.catch		
U3b	@	(Plugin):cpm_plugin.js:2013
d	@	(Plugin):cpm_plugin.js:18
（匿名）	@	file_system.ts:224
e	@	file_system.ts:166
i	@	file_system.ts:109
v3b	@	(Plugin):cpm_plugin.js:1998
F6b	@	(Plugin):cpm_plugin.js:2109
bac	@	(Plugin):cpm_plugin.js:2239
d	@	(Plugin):cpm_plugin.js:18
Ze	@	vue.min.js:11
B	@	vue.min.js:11
K6.G._wrapper	@	vue.min.js:11
```

As noted in the [MDN Window.btoa() documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa#unicode_strings), `btoa()` only supports ASCII and lacks built-in Unicode support. This causes errors when processing non-ASCII characters, including internationalized (i18n) text.

Before fix:

https://github.com/user-attachments/assets/8ea39ed9-3e2e-4817-aee6-c67b91aaf62b

After fix:

https://github.com/user-attachments/assets/cb03ae5c-6de1-4e5c-ae68-009068f0ac90
